### PR TITLE
Use the artifactId as the full image URI

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -76,7 +76,7 @@ func (n *ArtifactPackagedEventHandler) HandleCDEvent(e *event.Event) {
 		},
 		ConfigurationChange: keptnv2.ConfigurationChange{
 			Values: map[string]interface{}{
-				"image": "docker.io/salaboy/" + artifactExtension.ArtifactName + ":" + artifactExtension.ArtifactVersion,
+				"image": artifactExtension.ArtifactId,
 			},
 		},
 	}


### PR DESCRIPTION
Use the artifactId to transport the full image URI so that we do
not need to hardcode the registry in the translator.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>